### PR TITLE
feat: add form status inspired by Inertia

### DIFF
--- a/playground/app/components/NuxtForm.vue
+++ b/playground/app/components/NuxtForm.vue
@@ -163,6 +163,11 @@ async function onSubmit(event: FormSubmitEvent<LoginForm>) {
     </div>
 
     <div>
+      <strong>Recently Successful:</strong>
+      <pre>{{ form.recentlySuccessful }}</pre>
+    </div>
+
+    <div>
       <strong>Processing:</strong>
       <pre>{{ form.processing }}</pre>
     </div>

--- a/playground/app/components/NuxtForm.vue
+++ b/playground/app/components/NuxtForm.vue
@@ -158,6 +158,11 @@ async function onSubmit(event: FormSubmitEvent<LoginForm>) {
 
   <div class="flex flex-col mt-4 gap-4">
     <div>
+      <strong>Was Successful:</strong>
+      <pre>{{ form.wasSuccessful }}</pre>
+    </div>
+
+    <div>
       <strong>Processing:</strong>
       <pre>{{ form.processing }}</pre>
     </div>

--- a/playground/app/components/SimpleForm.vue
+++ b/playground/app/components/SimpleForm.vue
@@ -189,6 +189,11 @@ async function submit() {
     </div>
 
     <div>
+      <strong>Recently Successful:</strong>
+      <pre>{{ form.recentlySuccessful }}</pre>
+    </div>
+
+    <div>
       <strong>Processing:</strong>
       <pre>{{ form.processing }}</pre>
     </div>

--- a/playground/app/components/SimpleForm.vue
+++ b/playground/app/components/SimpleForm.vue
@@ -184,6 +184,11 @@ async function submit() {
     </UButtonGroup>
 
     <div>
+      <strong>Was Successful:</strong>
+      <pre>{{ form.wasSuccessful }}</pre>
+    </div>
+
+    <div>
       <strong>Processing:</strong>
       <pre>{{ form.processing }}</pre>
     </div>

--- a/src/runtime/composables/usePrecognitionForm.ts
+++ b/src/runtime/composables/usePrecognitionForm.ts
@@ -137,6 +137,7 @@ export const usePrecognitionForm = <T extends Payload>(
     validating: false,
     hasErrors: computed(() => Object.keys(form.errors).length > 0) as unknown as boolean,
     wasSuccessful: false,
+    recentlySuccessful: false,
 
     touched: (name: PayloadKey<T>): boolean => _touched.value.includes(name),
     valid: (name: PayloadKey<T>): boolean => _validated.value.includes(name) && !form.invalid(name),
@@ -283,6 +284,13 @@ export const usePrecognitionForm = <T extends Payload>(
       return await process()
         .then((response) => {
           form.wasSuccessful = true
+          form.recentlySuccessful = true
+
+          debounce(
+            () => { form.recentlySuccessful = false },
+            2000,
+          )()
+
           return response
         })
         .catch((response) => {

--- a/src/runtime/composables/usePrecognitionForm.ts
+++ b/src/runtime/composables/usePrecognitionForm.ts
@@ -136,6 +136,7 @@ export const usePrecognitionForm = <T extends Payload>(
     processing: false,
     validating: false,
     hasErrors: computed(() => Object.keys(form.errors).length > 0) as unknown as boolean,
+    wasSuccessful: false,
 
     touched: (name: PayloadKey<T>): boolean => _touched.value.includes(name),
     valid: (name: PayloadKey<T>): boolean => _validated.value.includes(name) && !form.invalid(name),
@@ -280,6 +281,14 @@ export const usePrecognitionForm = <T extends Payload>(
       form.processing = true
 
       return await process()
+        .then((response) => {
+          form.wasSuccessful = true
+          return response
+        })
+        .catch((response) => {
+          form.wasSuccessful = false
+          return response
+        })
         .finally(() => form.processing = false)
     },
   }) as PrecognitionForm<T>

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -105,6 +105,10 @@ export interface PrecognitionForm<T extends Payload> {
    * Whether the form has any errors.
    */
   hasErrors: boolean
+  /**
+   * Becomes true when a form has been successfully submitted.
+   */
+  wasSuccessful: boolean
 
   /**
    * Checks if a form field has been touched.

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -109,6 +109,11 @@ export interface PrecognitionForm<T extends Payload> {
    * Becomes true when a form has been successfully submitted.
    */
   wasSuccessful: boolean
+  /**
+   * Becomes true for two seconds after a successful form submission.
+   * This property can be used to show temporary success messages.
+   */
+  recentlySuccessful: boolean
 
   /**
    * Checks if a form field has been touched.


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

Closes #39 by introducing two reactive form fields:
- `wasSuccessful`
- `recentlySuccessful`

The behaviour is the same as described in the Inertia docs - [Form Helper](https://inertiajs.com/forms#form-helper).
