### PR TITLE
Allow partial payloads in `setData()` to match documented behavior

### DIFF
--- a/src/runtime/composables/usePrecognitionForm.ts
+++ b/src/runtime/composables/usePrecognitionForm.ts
@@ -3,6 +3,7 @@ import { debounce, isEqual } from 'lodash-es'
 import { objectToFormData } from 'object-form-encoder'
 import type {
   Payload,
+  PayloadData,
   PayloadErrors,
   PayloadKey,
   PrecognitionForm,
@@ -144,7 +145,7 @@ export const usePrecognitionForm = <T extends Payload>(
       return toRaw(form.fields) as T
     },
 
-    setData(data: Partial<T>): PrecognitionForm<T> {
+    setData(data: Partial<PayloadData<T>>): PrecognitionForm<T> {
       Object
         .keys(data)
         .forEach((key: PayloadKey<T>) => {

--- a/src/runtime/composables/usePrecognitionForm.ts
+++ b/src/runtime/composables/usePrecognitionForm.ts
@@ -3,7 +3,6 @@ import { debounce, isEqual } from 'lodash-es'
 import { objectToFormData } from 'object-form-encoder'
 import type {
   Payload,
-  PayloadData,
   PayloadErrors,
   PayloadKey,
   PrecognitionForm,
@@ -145,7 +144,7 @@ export const usePrecognitionForm = <T extends Payload>(
       return toRaw(form.fields) as T
     },
 
-    setData(data: PayloadData<T>): PrecognitionForm<T> {
+    setData(data: Partial<T>): PrecognitionForm<T> {
       Object
         .keys(data)
         .forEach((key: PayloadKey<T>) => {


### PR DESCRIPTION
The current type definition for `setData()` requires all keys of the payload type (`PayloadData<T> = Record<keyof T, unknown>`), including optional ones, which contradicts the documented behavior that mentions partial updates: https://manchenkoff.gitbook.io/nuxt-sanctum-precognition/composables/useprecognitionform#data

```ts
interface User {
  name: string
  age?: number
}

// Partial update without the optional property should be valid
form.setData({ name: 'manchenkoff' })
```