### PR TITLE
Rethrow non-2xx responses in `submit()`

### DIFF
--- a/src/runtime/composables/usePrecognitionForm.ts
+++ b/src/runtime/composables/usePrecognitionForm.ts
@@ -295,7 +295,7 @@ export const usePrecognitionForm = <T extends Payload>(
         })
         .catch((response) => {
           form.wasSuccessful = false
-          return response
+          throw response
         })
         .finally(() => form.processing = false)
     },


### PR DESCRIPTION
The `submit()` method resolves promises for non-2xx responses (e.g., 500), preventing proper error handling in `try/catch` blocks. This action contradicts the documented behavior: https://manchenkoff.gitbook.io/nuxt-sanctum-precognition/error-handling#submission

```ts
try {
  const response = await form.submit()
  // ...
  console.log('success') // runs even on status 500
}
catch (e) {
  console.error('error', e) // never runs for non-2xx
}
```

This PR is proposed to fix above situation.